### PR TITLE
appointment model: clean() and save() improvements

### DIFF
--- a/appointment/models.py
+++ b/appointment/models.py
@@ -310,7 +310,7 @@ class AppointmentRequest(models.Model):
 
     def clean(self):
         if self.start_time is not None and self.end_time is not None:
-            if self.start_time >= self.end_time:
+            if self.start_time > self.end_time:
                 raise ValidationError(_("Start time must be before end time"))
             if self.start_time == self.end_time:
                 raise ValidationError(_("Start time and end time cannot be the same"))

--- a/appointment/models.py
+++ b/appointment/models.py
@@ -311,9 +311,9 @@ class AppointmentRequest(models.Model):
     def clean(self):
         if self.start_time is not None and self.end_time is not None:
             if self.start_time >= self.end_time:
-                raise ValueError(_("Start time must be before end time"))
+                raise ValidationError(_("Start time must be before end time"))
             if self.start_time == self.end_time:
-                raise ValueError(_("Start time and end time cannot be the same"))
+                raise ValidationError(_("Start time and end time cannot be the same"))
         # Check for valid date
         try:
             # This will raise a ValueError if the date is not valid

--- a/appointment/models.py
+++ b/appointment/models.py
@@ -314,12 +314,6 @@ class AppointmentRequest(models.Model):
                 raise ValidationError(_("Start time must be before end time"))
             if self.start_time == self.end_time:
                 raise ValidationError(_("Start time and end time cannot be the same"))
-        # Check for valid date
-        try:
-            # This will raise a ValueError if the date is not valid
-            datetime.datetime.strptime(str(self.date), '%Y-%m-%d')
-        except ValueError:
-            raise ValidationError(_("The date is not valid"))
 
         # Ensure the date is not in the past:
         if self.date < datetime.date.today():
@@ -338,10 +332,6 @@ class AppointmentRequest(models.Model):
         # duration should not exceed the service duration
         if time_difference(self.start_time, self.end_time) > self.service.duration:
             raise ValidationError(_("Duration cannot exceed the service duration"))
-        try:
-            datetime.datetime.strptime(str(self.date), '%Y-%m-%d')
-        except ValueError:
-            raise ValidationError(_("The date is not valid"))
         return super().save(*args, **kwargs)
 
     def get_service_name(self):


### PR DESCRIPTION
* because of the `>=` in `if self.start_time >= self.end_time:`, the `if self.start_time == self.end_time:` can never be reached
* ValueError is not the right error to raise, It's ValidationError. Raising ValueError throws a 500 
* The date field already checks for date validity

Nit: all the checks in the `save()` should be removed, they are already done in `clean()` (except one but I can move it into clean`). In Django, all checks are done `clean`, and not in save. The way it's done is contrary to the django philosophy (yes theoretically a silly dev could call save with invalid data because he did not call `clean()` but django is clear on it:  that's his fault).
If you are OK with this proposal, I will do this.