### PR TITLE
delete get_timezone and APP_TIME_ZONE

### DIFF
--- a/appointment/settings.py
+++ b/appointment/settings.py
@@ -21,7 +21,6 @@ APPOINTMENT_BUFFER_TIME = getattr(settings, 'APPOINTMENT_BUFFER_TIME', 0)
 APPOINTMENT_LEAD_TIME = getattr(settings, 'APPOINTMENT_LEAD_TIME', (9, 0))
 APPOINTMENT_FINISH_TIME = getattr(settings, 'APPOINTMENT_FINISH_TIME', (18, 30))
 APP_DEFAULT_FROM_EMAIL = getattr(settings, 'DEFAULT_FROM_EMAIL', DEFAULT_FROM_EMAIL)
-APP_TIME_ZONE = getattr(settings, 'TIME_ZONE', 'America/New_York')
 
 
 def check_q_cluster():

--- a/appointment/tests/test_utils.py
+++ b/appointment/tests/test_utils.py
@@ -16,8 +16,7 @@ from appointment.models import Appointment, AppointmentRequest, Config, Service,
 from appointment.services import get_available_slots, get_finish_button_text
 from appointment.settings import APPOINTMENT_BUFFER_TIME, APPOINTMENT_FINISH_TIME, APPOINTMENT_LEAD_TIME, \
     APPOINTMENT_SLOT_DURATION, APPOINTMENT_WEBSITE_NAME
-from appointment.utils.date_time import combine_date_and_time, convert_str_to_date, get_current_year, get_timestamp, \
-    get_timezone
+from appointment.utils.date_time import combine_date_and_time, convert_str_to_date, get_current_year, get_timestamp
 from appointment.utils.db_helpers import get_appointment_buffer_time, get_appointment_finish_time, \
     get_appointment_lead_time, get_appointment_slot_duration, get_user_model, get_website_name
 from appointment.utils.view_helpers import generate_random_id, get_locale, is_ajax
@@ -126,10 +125,6 @@ class UtilityTestCase(TestCase):
     # Test cases for get_current_year
     def test_get_current_year(self):
         self.assertEqual(get_current_year(), datetime.datetime.now().year)
-
-    # Test cases for get_timezone
-    def test_get_timezone(self):
-        self.assertIsNotNone(get_timezone())
 
     # Test cases for convert_str_to_date
     def test_convert_str_to_date_valid(self):

--- a/appointment/tests/utils/test_date_time.py
+++ b/appointment/tests/utils/test_date_time.py
@@ -10,7 +10,7 @@ from appointment.settings import APP_TIME_ZONE
 from appointment.utils.date_time import (
     combine_date_and_time, convert_12_hour_time_to_24_hour_time, convert_24_hour_time_to_12_hour_time,
     convert_minutes_in_human_readable_format, convert_str_to_date,
-    convert_str_to_time, get_ar_end_time, get_current_year, get_timestamp, get_timezone, get_weekday_num,
+    convert_str_to_time, get_ar_end_time, get_current_year, get_timestamp, get_weekday_num,
     time_difference
 )
 
@@ -378,10 +378,6 @@ class TimestampTests(TestCase):
 
 
 class GeneralDateTimeTests(TestCase):
-    def test_get_timezone(self):
-        """Test get_timezone function"""
-        self.assertEqual(get_timezone(), APP_TIME_ZONE)
-
     def test_get_current_year(self):
         """Test get_current_year function"""
         self.assertEqual(get_current_year(), datetime.datetime.now().year)
@@ -391,11 +387,6 @@ class GeneralDateTimeTests(TestCase):
         with patch('appointment.utils.date_time.datetime.datetime') as mock_date:
             mock_date.now.return_value.year = 1999  # Setting year attribute of the mock object
             self.assertEqual(get_current_year(), 1999)
-
-    @patch('appointment.utils.date_time.APP_TIME_ZONE', new="Asia/Tokyo")
-    def test_get_timezone_with_modified_setting(self):
-        """Test get_timezone function with a modified timezone setting."""
-        self.assertEqual(get_timezone(), "Asia/Tokyo")
 
     def test_get_weekday_num(self):
         """Test get_weekday_num function with valid input"""

--- a/appointment/tests/utils/test_date_time.py
+++ b/appointment/tests/utils/test_date_time.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from appointment.settings import APP_TIME_ZONE
 from appointment.utils.date_time import (
     combine_date_and_time, convert_12_hour_time_to_24_hour_time, convert_24_hour_time_to_12_hour_time,
     convert_minutes_in_human_readable_format, convert_str_to_date,

--- a/appointment/utils/date_time.py
+++ b/appointment/utils/date_time.py
@@ -11,8 +11,6 @@ import datetime
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
 
-from appointment.settings import APP_TIME_ZONE
-
 
 def combine_date_and_time(date, time) -> datetime.datetime:
     """Combine a date and a time into a datetime object.

--- a/appointment/utils/date_time.py
+++ b/appointment/utils/date_time.py
@@ -180,11 +180,6 @@ def get_ar_end_time(start_time, duration) -> datetime.time:
     return dt_end_time.time()
 
 
-def get_timezone() -> str:
-    """Return the current timezone of the application."""
-    return APP_TIME_ZONE
-
-
 def get_timestamp() -> str:
     """Get the current timestamp as a string without the decimal part.
 

--- a/appointment/utils/json_context.py
+++ b/appointment/utils/json_context.py
@@ -10,9 +10,9 @@ import pytz
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
+from django.conf import settings
 
 from appointment.settings import APPOINTMENT_ADMIN_BASE_TEMPLATE, APPOINTMENT_BASE_TEMPLATE
-from appointment.utils.date_time import get_timezone
 from appointment.utils.db_helpers import username_in_user_model
 from appointment.utils.error_codes import ErrorCode
 
@@ -20,7 +20,7 @@ from appointment.utils.error_codes import ErrorCode
 def convert_appointment_to_json(request, appointments: list) -> list:
     """Convert a queryset of Appointment objects to a JSON serializable format."""
     su = request.user.is_superuser
-    tz = pytz.timezone(get_timezone())
+    tz = pytz.timezone(settings.TIME_ZONE)
     return [{
         "id": appt.id,
         "client": appt.client.username if username_in_user_model() else "",
@@ -36,7 +36,7 @@ def convert_appointment_to_json(request, appointments: list) -> list:
         "service_id": appt.get_service().id,
         "additional_info": appt.additional_info,
         "want_reminder": appt.want_reminder,
-        "timezone": get_timezone(),
+        "timezone": settings.TIME_ZONE,
     } for appt in appointments]
 
 
@@ -58,7 +58,7 @@ def get_generic_context(request, admin=True):
     return {
         'BASE_TEMPLATE': APPOINTMENT_ADMIN_BASE_TEMPLATE if admin else APPOINTMENT_BASE_TEMPLATE,
         'user': request.user,
-        'timezone': get_timezone(),
+        'timezone': settings.TIME_ZONE,
     }
 
 

--- a/appointment/utils/view_helpers.py
+++ b/appointment/utils/view_helpers.py
@@ -8,9 +8,8 @@ Since: 2.0.0
 
 import uuid
 
+from django.conf import settings
 from django.utils.translation import get_language, to_locale
-
-from appointment.settings import APP_TIME_ZONE
 
 
 def get_locale() -> str:
@@ -49,7 +48,7 @@ def get_timezone_txt() -> str:
 
     :return: The current timezone in a string format.
     """
-    tmz = APP_TIME_ZONE
+    tmz = settings.TIME_ZONE
     timezone_map = {
         'UTC': 'Universal Time Coordinated (UTC)',
         'US/Eastern': 'Eastern Daylight Time (US & Canada)',

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -9,6 +9,7 @@ Since: 1.0.0
 from datetime import date, datetime, timedelta
 
 import pytz
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.forms import SetPasswordForm
@@ -41,7 +42,7 @@ from appointment.utils.view_helpers import get_locale, get_timezone_txt
 from .decorators import require_ajax
 from .messages_ import passwd_error, passwd_set_successfully
 from .services import get_appointments_and_slots, get_available_slots_for_staff
-from .settings import (APPOINTMENT_PAYMENT_URL, APPOINTMENT_THANK_YOU_URL, APP_TIME_ZONE)
+from .settings import (APPOINTMENT_PAYMENT_URL, APPOINTMENT_THANK_YOU_URL)
 from .utils.date_time import convert_str_to_date, convert_str_to_time
 from .utils.error_codes import ErrorCode
 from .utils.json_context import get_generic_context_with_extra, json_response
@@ -96,7 +97,7 @@ def get_available_slots_ajax(request):
     # Check if the selected_date is today and filter out past slots
     if selected_date == date.today():
         # Get the current time in EDT timezone
-        current_time_edt = datetime.now(pytz.timezone(APP_TIME_ZONE)).time()
+        current_time_edt = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
         available_slots = [slot for slot in available_slots if convert_str_to_time(slot) > current_time_edt]
 
     custom_data['available_slots'] = available_slots

--- a/docs/utils/date_time.md
+++ b/docs/utils/date_time.md
@@ -26,7 +26,6 @@ system.
 ## Date Time Utilities:
 
 - **get_ar_end_time**: Calculate the end time of an appointment request based on its start time and duration.
-- **get_timezone**: Retrieve the current timezone of the application.
 - **get_timestamp**: Obtain the current timestamp as a string without the decimal part.
 - **time_difference**: Calculate the difference between two times.
 


### PR DESCRIPTION
`get_timezone` is not needed: settings.TIME_ZONE can be used and is guaranteed to exist and be valid. The fallback of APP_TIME_ZONE, despite it should never happen since TIME_ZONE necessarily exist, is misleading: nowhere in Django the default timezone is `America/New York` (it was the default parameter for the project generation years ago and it's not the case anymore, see the doc https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-TIME_ZONE).

Still a draft currently. Don't mind the "parallelize test runs" commit.