### PR TITLE
let django handle the timezone

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,6 @@ This project depends on several third-party libraries:
 - phonenumbers==8.13.25
 - django-phonenumber-field==7.2.0
 - babel==2.13.1
-- pytz~=2023.3.post1
 
 We strive to keep these dependencies up to date and free from vulnerabilities. If you find a vulnerability in one of
 these dependencies, please follow the steps above to report it.

--- a/appointment/__init__.py
+++ b/appointment/__init__.py
@@ -5,5 +5,5 @@ __description__ = "Managing appointment scheduling with customizable slots, staf
 __package_name__ = "django-appointment"
 __url__ = "https://github.com/adamspd/django-appointment"
 __package_website__ = "https://django-appt.adamspierredavid.com/"
-__version__ = "3.3.9"
+__version__ = "3.4.0"
 __test_version__ = False

--- a/appointment/services.py
+++ b/appointment/services.py
@@ -434,9 +434,7 @@ def get_available_slots_for_staff(date, staff_member):
     slots = exclude_pending_reschedules(slots, staff_member, date)
     appointments = get_appointments_for_date_and_time(date, working_hours_dict['start_time'],
                                                       working_hours_dict['end_time'], staff_member)
-    slots = exclude_booked_slots(appointments, slots, slot_duration)
-
-    return [slot.strftime('%I:%M %p') for slot in slots]
+    return exclude_booked_slots(appointments, slots, slot_duration)
 
 
 def get_finish_button_text(service) -> str:

--- a/appointment/static/js/appointments.js
+++ b/appointment/static/js/appointments.js
@@ -10,6 +10,7 @@ let isRequestInProgress = false;
 const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     initialDate: selectedDate,
+    timeZone: timezone,
     headerToolbar: {
         left: 'title',
         right: 'prev,today,next',

--- a/appointment/templates/appointment/appointments.html
+++ b/appointment/templates/appointment/appointments.html
@@ -109,7 +109,7 @@
             integrity="sha512-JCQkxdym6GmQ+AFVioDUq8dWaWN6tbKRhRyHvYZPupQ6DxpXzkW106FXS1ORgo/m3gxtt5lHRMqSdm2OfPajtg=="
             crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>
-        const timezone = "{{ timezone }}";
+        const timezone = "{{ timezoneTxt }}";
         const locale = "{{ locale }}";
         const availableSlotsAjaxURL = "{% url 'appointment:available_slots_ajax' %}";
         const requestNextAvailableSlotURLTemplate = "{% url 'appointment:request_next_available_slot' service_id=0 %}";

--- a/appointment/tests/test_services.py
+++ b/appointment/tests/test_services.py
@@ -471,8 +471,9 @@ class GetAvailableSlotsTests(BaseTest):
         """Test if available slots are returned correctly."""
         # On a Wednesday, the staff member should have slots from 9 AM to 5 PM
         slots = get_available_slots_for_staff(self.next_wednesday, self.staff_member1)
-        expected_slots = [f"{hour:02d}:00 AM" for hour in range(9, 12)] + ["12:00 PM"] + \
-                         [f"{hour:02d}:00 PM" for hour in range(1, 5)]
+        expected_slots = [
+            datetime.datetime(self.next_wednesday.year, self.next_wednesday.month, self.next_wednesday.day, hour) for
+            hour in range(9, 17)]
         self.assertEqual(slots, expected_slots)
 
     def test_booked_slots(self):
@@ -490,7 +491,9 @@ class GetAvailableSlotsTests(BaseTest):
 
         # Now, the staff member should not have that slot available
         slots = get_available_slots_for_staff(self.next_wednesday, self.staff_member1)
-        expected_slots = ['09:00 AM', '11:00 AM', '12:00 PM', '01:00 PM', '02:00 PM', '03:00 PM', '04:00 PM']
+        expected_slots = [
+            datetime.datetime(self.next_wednesday.year, self.next_wednesday.month, self.next_wednesday.day, hour, 0) for
+            hour in range(9, 17) if hour != 10]
         self.assertEqual(slots, expected_slots)
 
     def test_no_working_hours(self):

--- a/appointment/utils/json_context.py
+++ b/appointment/utils/json_context.py
@@ -6,11 +6,9 @@ Author: Adams Pierre David
 Since: 2.0.0
 """
 
-import pytz
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.conf import settings
 
 from appointment.settings import APPOINTMENT_ADMIN_BASE_TEMPLATE, APPOINTMENT_BASE_TEMPLATE
 from appointment.utils.db_helpers import username_in_user_model
@@ -20,12 +18,11 @@ from appointment.utils.error_codes import ErrorCode
 def convert_appointment_to_json(request, appointments: list) -> list:
     """Convert a queryset of Appointment objects to a JSON serializable format."""
     su = request.user.is_superuser
-    tz = pytz.timezone(settings.TIME_ZONE)
     return [{
         "id": appt.id,
         "client": appt.client.username if username_in_user_model() else "",
-        "start_time": tz.localize(appt.get_start_time()).isoformat(),
-        "end_time": tz.localize(appt.get_end_time()).isoformat(),
+        "start_time": appt.get_start_time().isoformat(),
+        "end_time": appt.get_end_time().isoformat(),
         "client_name": appt.get_client_name(),
         "url": appt.get_absolute_url(request),
         "background_color": appt.get_background_color(),
@@ -37,7 +34,6 @@ def convert_appointment_to_json(request, appointments: list) -> list:
         "staff_id": appt.appointment_request.staff_member.id,
         "additional_info": appt.additional_info,
         "want_reminder": appt.want_reminder,
-        "timezone": settings.TIME_ZONE,
     } for appt in appointments]
 
 
@@ -59,7 +55,6 @@ def get_generic_context(request, admin=True):
     return {
         'BASE_TEMPLATE': APPOINTMENT_ADMIN_BASE_TEMPLATE if admin else APPOINTMENT_BASE_TEMPLATE,
         'user': request.user,
-        'timezone': settings.TIME_ZONE,
         'is_superuser': request.user.is_superuser,
     }
 

--- a/appointment/utils/view_helpers.py
+++ b/appointment/utils/view_helpers.py
@@ -39,26 +39,3 @@ def generate_random_id() -> str:
     :return: The randomly generated UUID as a hex string
     """
     return uuid.uuid4().hex
-
-
-def get_timezone_txt() -> str:
-    # TODO: To be better implemented in the future
-    """Get the current timezone as a string. To be used in the HTML template when the user is choosing the appointment's
-    time.
-
-    :return: The current timezone in a string format.
-    """
-    tmz = settings.TIME_ZONE
-    timezone_map = {
-        'UTC': 'Universal Time Coordinated (UTC)',
-        'US/Eastern': 'Eastern Daylight Time (US & Canada)',
-        'US/Central': 'Central Time (US & Canada)',
-        'US/Mountain': 'Mountain Time (US & Canada)',
-        'US/Pacific': 'Pacific Time (US & Canada)',
-        'US/Alaska': 'Alaska Time (US & Canada)',
-        'US/Hawaii': 'Hawaii Time (US & Canada)',
-        'Europe/Paris': 'Paris Time (Europe)',
-        'Europe/London': 'London Time (Europe)',
-        'EDT': 'Eastern Daylight Time (US & Canada)',
-    }
-    return timezone_map.get(tmz, 'Universal Time Coordinated (UTC)')

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -97,8 +97,7 @@ def get_available_slots_ajax(request):
 
     # Check if the selected_date is today and filter out past slots
     if selected_date == date.today():
-        # Get the current time in EDT timezone
-        current_time_edt = datetime.now(pytz.timezone('Europe/Paris')).time()
+        current_time_edt = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
         available_slots = [slot for slot in available_slots if convert_str_to_time(slot) > current_time_edt]
 
     custom_data['available_slots'] = available_slots

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -98,7 +98,7 @@ def get_available_slots_ajax(request):
     # Check if the selected_date is today and filter out past slots
     if selected_date == date.today():
         # Get the current time in EDT timezone
-        current_time_edt = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
+        current_time_edt = datetime.now(pytz.timezone('Europe/Paris')).time()
         available_slots = [slot for slot in available_slots if convert_str_to_time(slot) > current_time_edt]
 
     custom_data['available_slots'] = available_slots

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -19,6 +19,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
+from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext as _
 
 from appointment.forms import AppointmentForm, AppointmentRequestForm
@@ -38,7 +39,7 @@ from appointment.utils.email_ops import notify_admin_about_appointment, notify_a
     send_reschedule_confirmation_email, \
     send_thank_you_email
 from appointment.utils.session import get_appointment_data_from_session, handle_existing_email
-from appointment.utils.view_helpers import get_locale, get_timezone_txt
+from appointment.utils.view_helpers import get_locale
 from .decorators import require_ajax
 from .messages_ import passwd_error, passwd_set_successfully
 from .services import get_appointments_and_slots, get_available_slots_for_staff
@@ -219,7 +220,7 @@ def appointment_request(request, service_id=None, staff_member_id=None):
         'available_slots': available_slots,
         'date_chosen': date_chosen,
         'locale': get_locale(),
-        'timezoneTxt': get_timezone_txt(),
+        'timezoneTxt': get_current_timezone_name(),
         'label': label
     }
     context = get_generic_context_with_extra(request, extra_context, admin=False)
@@ -527,7 +528,7 @@ def prepare_reschedule_appointment(request, id_request):
         'available_slots': available_slots,
         'date_chosen': date_chosen,
         'locale': get_locale(),
-        'timezoneTxt': get_timezone_txt(),
+        'timezoneTxt': get_current_timezone_name(),
         'label': label,
         'rescheduled_date': ar.date.strftime("%Y-%m-%d"),
         'page_header': page_title,

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -97,10 +97,10 @@ def get_available_slots_ajax(request):
 
     # Check if the selected_date is today and filter out past slots
     if selected_date == date.today():
-        current_time_edt = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
-        available_slots = [slot for slot in available_slots if convert_str_to_time(slot) > current_time_edt]
+        current_time = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
+        available_slots = [slot for slot in available_slots if slot.time() > current_time]
 
-    custom_data['available_slots'] = available_slots
+    custom_data['available_slots'] = [slot.strftime('%I:%M %p') for slot in available_slots]
     if len(available_slots) == 0:
         custom_data['error'] = True
         message = _('No availability')
@@ -524,7 +524,7 @@ def prepare_reschedule_appointment(request, id_request):
         'all_staff_members': all_staff_members,
         'page_title': page_title,
         'page_description': page_description,
-        'available_slots': available_slots,
+        'available_slots': [slot.strftime('%I:%M %p') for slot in available_slots],
         'date_chosen': date_chosen,
         'locale': get_locale(),
         'timezoneTxt': get_current_timezone_name(),

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -6,10 +6,8 @@ Author: Adams Pierre David
 Since: 1.0.0
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
-import pytz
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.forms import SetPasswordForm
@@ -17,6 +15,7 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from django.utils.timezone import get_current_timezone_name
@@ -44,7 +43,7 @@ from .decorators import require_ajax
 from .messages_ import passwd_error, passwd_set_successfully
 from .services import get_appointments_and_slots, get_available_slots_for_staff
 from .settings import (APPOINTMENT_PAYMENT_URL, APPOINTMENT_THANK_YOU_URL)
-from .utils.date_time import convert_str_to_date, convert_str_to_time
+from .utils.date_time import convert_str_to_date
 from .utils.error_codes import ErrorCode
 from .utils.json_context import get_generic_context_with_extra, json_response
 
@@ -97,7 +96,7 @@ def get_available_slots_ajax(request):
 
     # Check if the selected_date is today and filter out past slots
     if selected_date == date.today():
-        current_time = datetime.now(pytz.timezone(settings.TIME_ZONE)).time()
+        current_time = timezone.now().time()
         available_slots = [slot for slot in available_slots if slot.time() > current_time]
 
     custom_data['available_slots'] = [slot.strftime('%I:%M %p') for slot in available_slots]

--- a/appointments/settings.py
+++ b/appointments/settings.py
@@ -110,7 +110,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en"
 
-TIME_ZONE = 'Europe/Paris'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 

--- a/docs/utils/view_helpers.md
+++ b/docs/utils/view_helpers.md
@@ -33,10 +33,3 @@ This module provides utility functions to support the Django views in the appoin
 
 - **generate_random_id()**:
     - Produces a random UUID in the form of a hexadecimal string.
-
-### Timezone Operations:
-
-- **get_timezone_txt()**:
-    - Retrieve the current timezone as a string, suitable for display purposes in the HTML templates when users choose
-      the appointment time.
-    - Note: The function implementation may be enhanced in the future.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,6 @@ phonenumbers==8.13.33
 django-phonenumber-field==7.3.0
 babel==2.14.0
 setuptools==69.2.0
-pytz~=2024.1
 requests~=2.31.0
 django-q2==1.6.2
 python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ phonenumbers==8.13.33
 django-phonenumber-field==7.3.0
 babel==2.14.0
 setuptools==69.2.0
-pytz~=2024.1
 requests~=2.31.0
 django-q2==1.6.2
 python-dotenv==1.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,5 +27,4 @@ install_requires =
     phonenumbers>=8.13.22
     django-phonenumber-field>=7.2.0
     babel>=2.13.0
-    pytz>=2023.3
     django-q2>=1.6.1


### PR DESCRIPTION
Current time zone handling of django-appointment is incorrect.
`settings.TIME_ZONE` is a fallback from the past for when correct time zone support was not present in Django. Now timezones works perfectly fine and you are not suppose to use the TIME_ZONE. Just use `get_current_timezone()` and let django handle the current user's timezone for you.
