### PR TITLE
Issue #455 - Fix unused var '_' overloading gettext '_' in appointmen…

### DIFF
--- a/appointment/views.py
+++ b/appointment/views.py
@@ -356,7 +356,7 @@ def appointment_client_information(request, appointment_request_id, id_request):
                 return handle_existing_email(request, client_data, appointment_data, appointment_request_id, id_request)
 
             logger.info(f"Creating a new user: {client_data}")
-            _ = create_new_user(client_data)
+            unused = create_new_user(client_data)
             messages.success(request, _("An account was created for you."))
 
             # Create a new appointment


### PR DESCRIPTION
Simple variable name change from "_" to unused to avoid error when invoking i18n

appointment/views.py@358
```
_ = create_new_user(client_data)
messages.success(request, _("An account was created for you."))
```

To :
```
unused = create_new_user(client_data)
messages.success(request, _("An account was created for you."))
```