### PR TITLE
Localize calendar 1stday and timeslots

### DIFF
--- a/appointment/models.py
+++ b/appointment/models.py
@@ -462,6 +462,9 @@ class AppointmentRequest(models.Model):
 
     def get_service_price(self):
         return self.service.get_price()
+    
+    def get_service_price_text(self):
+        return self.service.get_price_text()
 
     def get_service_down_payment(self):
         return self.service.get_down_payment()

--- a/appointment/services.py
+++ b/appointment/services.py
@@ -14,6 +14,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _, gettext_lazy as _
+from django.utils.formats import localize
 
 from appointment.forms import PersonalInformationForm, ServiceForm, StaffDaysOffForm, StaffWorkingHoursForm
 from appointment.messages_ import appt_updated_successfully
@@ -235,10 +236,6 @@ def handle_working_hours_form(staff_member, day_of_week, start_time, end_time, a
     if not (staff_member and day_of_week and start_time and end_time):
         return json_response(_("Invalid data."), status=400, success=False, error_code=ErrorCode.INVALID_DATA)
 
-    # Convert start time and end time to 24-hour format
-    start_time = convert_12_hour_time_to_24_hour_time(start_time)
-    end_time = convert_12_hour_time_to_24_hour_time(end_time)
-
     # Ensure start time is before end time
     if start_time >= end_time:
         return json_response(_("Start time must be before end time."), status=400, success=False,
@@ -408,7 +405,7 @@ def get_available_slots(date, appointments):
     buffer_time = now + buff_time if date == now.date() else now
     slots = calculate_slots(start_time, end_time, buffer_time, slot_duration)
     slots = exclude_booked_slots(appointments, slots, slot_duration)
-    return [slot.strftime('%I:%M %p') for slot in slots]
+    return [localize(slot.time()) for slot in slots]
 
 
 def get_available_slots_for_staff(date, staff_member, day_of_week: int, service=None):

--- a/appointment/static/js/appointments.js
+++ b/appointment/static/js/appointments.js
@@ -13,7 +13,7 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
     initialDate: selectedDate,
     timeZone: timezone,
     locale: locale,
-    firstDay: (typeof firstday !== 'undefined') ? firstday : 0, //Set the first as Sunday by default or use the value in appointments.html
+    firstDay: firstDayOfWeek, //Use locale format from django
     headerToolbar: {
         left: 'title',
         right: 'prev,today,next',
@@ -194,12 +194,16 @@ function convertTo24Hour(time12h) {
     const [time, modifier] = time12h.split(' ');
     let [hours, minutes] = time.split(':');
 
-    if (hours === '12') {
-        hours = '00';
-    }
+    //test if we need to convert
+    if (modifier !== undefined) {
+        //convert 12->24.
+        if (hours === '12') {
+            hours = '00';
+        }
 
-    if (modifier.toUpperCase() === 'PM') {
-        hours = parseInt(hours, 10) + 12;
+        if (modifier.toUpperCase() === 'PM') {
+            hours = parseInt(hours, 10) + 12;
+        }
     }
 
     return `${hours}:${minutes}`;

--- a/appointment/static/js/appointments.js
+++ b/appointment/static/js/appointments.js
@@ -13,6 +13,7 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
     initialDate: selectedDate,
     timeZone: timezone,
     locale: locale,
+    firstDay: (typeof firstday !== 'undefined') ? firstday : 0, //Set the first as Sunday by default or use the value in appointments.html
     headerToolbar: {
         left: 'title',
         right: 'prev,today,next',

--- a/appointment/templates/appointment/appointment_client_information.html
+++ b/appointment/templates/appointment/appointment_client_information.html
@@ -101,7 +101,7 @@
                                 <div class="payment-details-title">{% trans "Payment Details" %}</div>
                                 <div class="total">
                                     <div>{% trans "Total" %}</div>
-                                    <div>${{ ar.get_service_price }}</div>
+                                    <div>{{ ar.get_service_price_text }}</div>
                                 </div>
                                 <div class="payment-options">
                                     <button type="submit" class="btn btn-dark btn-pay-full" name="payment_type"

--- a/appointment/templates/appointment/appointments.html
+++ b/appointment/templates/appointment/appointments.html
@@ -111,6 +111,7 @@
     <script>
         const timezone = "{{ timezoneTxt }}";
         const locale = "{{ locale }}";
+        const firstDayOfWeek = "{{ first_day_of_week }}";
         const availableSlotsAjaxURL = "{% url 'appointment:available_slots_ajax' %}";
         const requestNextAvailableSlotURLTemplate = "{% url 'appointment:request_next_available_slot' service_id=0 %}";
         const getNonWorkingDaysURL = "{% url 'appointment:get_non_working_days_ajax' %}";

--- a/appointment/utils/email_ops.py
+++ b/appointment/utils/email_ops.py
@@ -20,7 +20,6 @@ from appointment.email_sender import notify_admin, send_email
 from appointment.logger_config import get_logger
 from appointment.models import Appointment, AppointmentRequest, EmailVerificationCode, PasswordResetToken
 from appointment.settings import APPOINTMENT_PAYMENT_URL
-from appointment.utils.date_time import convert_24_hour_time_to_12_hour_time
 from appointment.utils.db_helpers import get_absolute_url_, get_website_name, username_in_user_model
 from appointment.utils.ics_utils import generate_ics_file
 from appointment.utils.template_helpers import get_email_template
@@ -306,12 +305,12 @@ def send_reschedule_confirmation_email(request, reschedule_history, appointment_
     email_context = {
         'is_confirmation': True,
         'first_name': first_name,
-        'old_date': appointment_request.date.strftime("%A, %d %B %Y"),
-        'reschedule_date': reschedule_history.date.strftime("%A, %d %B %Y"),
-        'old_start_time': convert_24_hour_time_to_12_hour_time(appointment_request.start_time),
-        'start_time': convert_24_hour_time_to_12_hour_time(reschedule_history.start_time),
-        'old_end_time': convert_24_hour_time_to_12_hour_time(appointment_request.end_time),
-        'end_time': convert_24_hour_time_to_12_hour_time(reschedule_history.end_time),
+        'old_date': appointment_request.date,
+        'reschedule_date': reschedule_history.date,
+        'old_start_time': appointment_request.start_time,
+        'start_time': reschedule_history.start_time,
+        'old_end_time': appointment_request.end_time,
+        'end_time': reschedule_history.end_time,
         'confirmation_link': confirmation_link,
         'company': get_website_name(),
     }
@@ -341,12 +340,12 @@ def notify_admin_about_reschedule(reschedule_history, appointment_request, clien
         'client_name': client_name,
         'service_name': service_name,
         'reason_for_rescheduling': reason_for_rescheduling,
-        'old_date': appointment_request.date.strftime("%A, %d %B %Y"),
-        'reschedule_date': reschedule_history.date.strftime("%A, %d %B %Y"),
-        'old_start_time': convert_24_hour_time_to_12_hour_time(appointment_request.start_time),
-        'start_time': convert_24_hour_time_to_12_hour_time(reschedule_history.start_time),
-        'old_end_time': convert_24_hour_time_to_12_hour_time(appointment_request.end_time),
-        'end_time': convert_24_hour_time_to_12_hour_time(reschedule_history.end_time),
+        'old_date': appointment_request.date,
+        'reschedule_date': reschedule_history.date,
+        'old_start_time': appointment_request.start_time,
+        'start_time': reschedule_history.start_time,
+        'old_end_time': appointment_request.end_time,
+        'end_time': reschedule_history.end_time,
         'company': get_website_name(),
     }
 

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -356,7 +356,7 @@ def appointment_client_information(request, appointment_request_id, id_request):
                 return handle_existing_email(request, client_data, appointment_data, appointment_request_id, id_request)
 
             logger.info(f"Creating a new user: {client_data}")
-            _ = create_new_user(client_data)
+            unused = create_new_user(client_data)
             messages.success(request, _("An account was created for you."))
 
             # Create a new appointment

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -17,7 +17,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.encoding import force_str
-from django.utils.formats import date_format
+from django.utils.formats import date_format, localize, get_format
 from django.utils.http import urlsafe_base64_decode
 from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext as _
@@ -111,7 +111,7 @@ def get_available_slots_ajax(request):
         current_time = timezone.now().time()
         available_slots = [slot for slot in available_slots if slot.time() > current_time]
 
-    custom_data['available_slots'] = [slot.strftime('%I:%M %p') for slot in available_slots]
+    custom_data['available_slots'] = [localize(slot.time()) for slot in available_slots]
     if len(available_slots) == 0:
         custom_data['error'] = True
         custom_data['date_iso'] = selected_date.isoformat()
@@ -243,6 +243,7 @@ def appointment_request(request, service_id=None, staff_member_id=None):
         'date_chosen': date_chosen,
         'locale': get_locale(),
         'timezoneTxt': get_current_timezone_name(),
+        'first_day_of_week': get_format("FIRST_DAY_OF_WEEK"),
         'label': label
     }
     context = get_generic_context_with_extra(request, extra_context, admin=False)
@@ -549,10 +550,11 @@ def prepare_reschedule_appointment(request, id_request):
         'all_staff_members': all_staff_members,
         'page_title': page_title,
         'page_description': page_description,
-        'available_slots': [slot.strftime('%I:%M %p') for slot in available_slots],
+        'available_slots': [localize(slot.time()) for slot in available_slots],
         'date_chosen': date_chosen,
         'locale': get_locale(),
         'timezoneTxt': get_current_timezone_name(),
+        'first_day_of_week': get_format("FIRST_DAY_OF_WEEK"),
         'label': label,
         'rescheduled_date': ar.date.strftime("%Y-%m-%d"),
         'page_header': page_title,


### PR DESCRIPTION
As discussed by mail here's my current updates about i18n/l10n.

get_service_price_text is to avoid forcing $ as currency in service price.

About convert_12_hour_time_to_24_hour_time and its reverse method, they're removed from email templates (reschedule and confirm) to let django localize dates and formats according to locale.

To maintain backward compatibility with 12hours format, in convertTo24Hour (js) a test is added to avoid converting if already on the correct format. It's not the most clean way, but feel a decent compromise so don't hesitate to reject if it's not acceptable.


