### PR TITLE
Add request as optional parameters for send_verification_email in ord…

### DIFF
--- a/appointment/email_sender/email_sender.py
+++ b/appointment/email_sender/email_sender.py
@@ -55,19 +55,19 @@ def has_required_email_settings():
     return True
 
 
-def render_email_template(template_url, context):
+def render_email_template(template_url, context, request = None):
     if template_url:
-        return loader.render_to_string(template_url, context)
+        return loader.render_to_string(template_url, context, request = request)
     return ""
 
 
 def send_email(recipient_list, subject: str, template_url: str = None, context: dict = None, from_email=None,
-               message: str = None, attachments=None):
+               message: str = None, attachments=None, request=None):
     if not has_required_email_settings():
         return
 
     from_email = from_email or APP_DEFAULT_FROM_EMAIL
-    html_message = render_email_template(template_url, context)
+    html_message = render_email_template(template_url, context, request)
 
     if get_use_django_q_for_emails() and check_q_cluster() and DJANGO_Q_AVAILABLE:
         # Pass only the necessary data to construct the email

--- a/appointment/tests/utils/test_session.py
+++ b/appointment/tests/utils/test_session.py
@@ -73,7 +73,8 @@ class HandleExistingEmailTests(BaseTest):
         # Assert redirect
         self.assertEqual(response.status_code, 302)
         mock_send_verification_email.assert_called_once_with(user=mock_get_user_by_email.return_value,
-                                                             email=client_data['email'])
+                                                             email=client_data['email'],
+                                                             request=self.request)
         mock_get_user_by_email.assert_called_once_with(client_data['email'])
 
 
@@ -115,7 +116,7 @@ class HandleEmailChangeTests(BaseTest):
 
         # Assert redirect
         self.assertEqual(response.status_code, 302)
-        mock_send_verification_email.assert_called_once_with(user=self.hammond, email=new_email)
+        mock_send_verification_email.assert_called_once_with(user=self.hammond, email=new_email, request=self.request)
 
 
 class GetAppointmentDataFromSessionTests(BaseTest):

--- a/appointment/utils/email_ops.py
+++ b/appointment/utils/email_ops.py
@@ -261,7 +261,7 @@ def notify_admin_about_appointment(appointment, client_name: str):
     logger.info(f"Notifications sent for appointment {appointment.id}")
 
 
-def send_verification_email(user, email: str):
+def send_verification_email(user, email: str, request = None):
     """
     Send an email with a verification code to the user for email verification.
 
@@ -269,6 +269,7 @@ def send_verification_email(user, email: str):
 
     :param user: The user to verify the email address.
     :param email: The email address of the user.
+    :param request: (optional) Without the request, send_email cannot render the email template with custom context_processors.
     :return: None
     """
     code = EmailVerificationCode.generate_code(user=user)
@@ -287,7 +288,8 @@ def send_verification_email(user, email: str):
                     recipient_list=[email],
                     subject=_("Email Verification"),
                     template_url=template_path,
-                    context=email_context
+                    context=email_context,
+                    request=request
             )
         else:
             raise TemplateDoesNotExist("verification.html")

--- a/appointment/utils/session.py
+++ b/appointment/utils/session.py
@@ -48,7 +48,7 @@ def login_or_create_user_by_mail(request, client_data, appointment_data, appoint
         user = create_new_user(client_data)
         messages.success(request, _("An account was created for you."))
 
-    send_verification_email(user=user, email=client_data['email'])
+    send_verification_email(user=user, email=client_data['email'], request=request)
 
     # clean the session variables
     session_keys = ['email', 'phone', 'want_reminder', 'address', 'additional_info']
@@ -71,7 +71,7 @@ def login_or_create_user_by_mail(request, client_data, appointment_data, appoint
 
 
 def handle_email_change(request, user, email):
-    send_verification_email(user=user, email=email)
+    send_verification_email(user=user, email=email, request=request)
     # clean the session variables
     session_keys = ['email', 'old_email']
     for key in session_keys:


### PR DESCRIPTION
Very specific request :
I'm currently working on customizing the verification code email template, overriding mine and using "APPOINTMENT_CUSTOM_EMAILS_DIR" to fetch it. Only one thing's missing, my custom context operator which handle website company settings like contact email, phone.

After investigation, the root cause was render_email_template in send_email (email_sender.py@70) which cannot handle custom context operator if no request is passed.

I didn't found a cleaner way to so so, so I passed request as default None for each call in order to maintain backward compatibility. 